### PR TITLE
Add file parameter to validateSchema call to prevent "finish is not a…

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ var jsonLintPlugin = function(options) {
 
   function loadAndValidateSchema(data, file, finish) {
     if (schemaContent) {
-      validateSchema(data, finish)
+      validateSchema(data, file, finish)
     } else {
       fs.readFile(schema.src, 'utf-8', function(error, fileContent) {
         if (error) {


### PR DESCRIPTION
Fix for issue #2 

When a schema is already loaded into schemaContent, validateSchema is called with an incorrect number of arguments.