### PR TITLE
Issue #4 - Pass copy of parserOptions to validator functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,8 +68,9 @@ var jsonLintPlugin = function(options) {
   function validateSchema(data, file, finish) {
     var lastError
     try {
-      var validate = validator.compile(schemaContent, parserOptions)
-      var parsedData = validate(data, parserOptions)
+      var tempOptions = {...parserOptions }
+      var validate = validator.compile(schemaContent, tempOptions)
+      var parsedData = validate(data, tempOptions)
       formatOutput(parsedData, file)
     } catch (error) {
       lastError = error


### PR DESCRIPTION
This is one possible fix for Issue #4 

This makes a local copy of parserOptions and passes the copy to the validator functions. This seemed like the easiest way to fix this issue without causing too many side effects. 